### PR TITLE
Changes "average developers" to "most developers"  (drops 'mainstream')

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasierRDF
 
-_This repository is for experimental/exploratory work on making RDF easier to use, with the goal of making it easy enough for *average* developers (middle 33% of ability).  By "RDF" we mean the whole RDF ecosystem -- including SPARQL, OWL, tools, standards, educational materials, etc. -- everything that a developer touches when using RDF.  Our plan:_
+_This repository is for experimental/exploratory work on making RDF easier to use, with the goal of making it easy enough for most mainstream developers.  By "RDF" we mean the whole RDF ecosystem -- including SPARQL, OWL, tools, standards, educational materials, etc. -- everything that a developer touches when using RDF.  Our plan:_
 * _focus and coordinate community efforts;_
 * _build on existing standards whenever possible;_
 * _launch additional W3C Community Groups to tackle specific areas of need, including_
@@ -11,13 +11,13 @@ _This repository is for experimental/exploratory work on making RDF easier to us
 
 The value of RDF for graph data has been well proven, in many applications, over the 20+ years since it was first created.  However, difficulty of use has caused RDF to be categorized as a niche technology. This is unfortunate because it limits uptake and prevents RDF from being viewed as a viable choice for many use cases that would otherwise be an excellent fit.
 
-This work seeks to build upon our experience with RDF to examine how we can make it easier to use.  What aspects or gaps have caused difficulty?    How can RDF better support features that users commonly need and other graph databases offer?  How can we make RDF -- or a successor -- easy enough for *average* developers?
+This work seeks to build upon our experience with RDF to examine how we can make it easier to use.  What aspects or gaps have caused difficulty?    How can RDF better support features that users commonly need and other graph databases offer?  How can we make RDF -- or a successor -- easy enough for most mainstream developers?
 
 At the same time, businesses are now showing a rapidly growing interest in graph data.  Businesses have used relational databases for many years, but it is costly to adapt database schema and applications in response to evolving application needs.  Other graph and NoSQL databases have emerged to help meet this need.  Unfortunately, there is a lack of interoperability across existing graph data solutions, motivating [interest in open standards for an interchange framework](https://www.w3.org/Data/events/data-ws-2019/cfp.html).  RDF is an appealing vendor neutral framework for graph data, and is well positioned to take on the role of an interchange framework.  Although this interest in RDF as a graph interchange framework arose independently from the effort to make RDF easier, and has different goals, there is a natural overlap in motivation, and both efforts can benefit each other.
 
 ## Guiding principles
 
-**1. The goal is to make RDF -- or some RDF-based successor -- easy enough for *average* developers (middle 33%), who are new to RDF, to be consistently successful.**
+**1. The goal is to make RDF -- or some RDF-based successor -- easy enough for most mainstream developers, who are new to RDF, to be consistently successful.**
 
 **2. Solutions may involve anything in the RDF ecosystem: standards, tools, guidance, etc.  All options are on the table.**
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EasierRDF
 
-_This repository is for experimental/exploratory work on making RDF easier to use, with the goal of making it easy enough for most mainstream developers.  By "RDF" we mean the whole RDF ecosystem -- including SPARQL, OWL, tools, standards, educational materials, etc. -- everything that a developer touches when using RDF.  Our plan:_
+_This repository is for experimental/exploratory work on making RDF easier to use, with the goal of making it easy enough for most developers.  By "RDF" we mean the whole RDF ecosystem -- including SPARQL, OWL, tools, standards, educational materials, etc. -- everything that a developer touches when using RDF.  Our plan:_
 * _focus and coordinate community efforts;_
 * _build on existing standards whenever possible;_
 * _launch additional W3C Community Groups to tackle specific areas of need, including_
@@ -11,13 +11,13 @@ _This repository is for experimental/exploratory work on making RDF easier to us
 
 The value of RDF for graph data has been well proven, in many applications, over the 20+ years since it was first created.  However, difficulty of use has caused RDF to be categorized as a niche technology. This is unfortunate because it limits uptake and prevents RDF from being viewed as a viable choice for many use cases that would otherwise be an excellent fit.
 
-This work seeks to build upon our experience with RDF to examine how we can make it easier to use.  What aspects or gaps have caused difficulty?    How can RDF better support features that users commonly need and other graph databases offer?  How can we make RDF -- or a successor -- easy enough for most mainstream developers?
+This work seeks to build upon our experience with RDF to examine how we can make it easier to use.  What aspects or gaps have caused difficulty?    How can RDF better support features that users commonly need and other graph databases offer?  How can we make RDF -- or a successor -- easy enough for most developers?
 
 At the same time, businesses are now showing a rapidly growing interest in graph data.  Businesses have used relational databases for many years, but it is costly to adapt database schema and applications in response to evolving application needs.  Other graph and NoSQL databases have emerged to help meet this need.  Unfortunately, there is a lack of interoperability across existing graph data solutions, motivating [interest in open standards for an interchange framework](https://www.w3.org/Data/events/data-ws-2019/cfp.html).  RDF is an appealing vendor neutral framework for graph data, and is well positioned to take on the role of an interchange framework.  Although this interest in RDF as a graph interchange framework arose independently from the effort to make RDF easier, and has different goals, there is a natural overlap in motivation, and both efforts can benefit each other.
 
 ## Guiding principles
 
-**1. The goal is to make RDF -- or some RDF-based successor -- easy enough for most mainstream developers, who are new to RDF, to be consistently successful.**
+**1. The goal is to make RDF -- or some RDF-based successor -- easy enough for most developers, who are new to RDF, to be consistently successful.**
 
 **2. Solutions may involve anything in the RDF ecosystem: standards, tools, guidance, etc.  All options are on the table.**
 


### PR DESCRIPTION
Per issue #79