### PR TITLE
Add reference to additional Python tools and fix missing link

### DIFF
--- a/RDF-LAMP.md
+++ b/RDF-LAMP.md
@@ -65,6 +65,8 @@ Tools in this section are for those using Python to build RDF applications.
 * [RDFLib](https://pypi.org/project/rdflib/) -- Python library for RDF applications.
 * (list others here ... )
 
+For a curated list of additional tools specifically for Python, see [semantic-python-overview](https://github.com/pysemtec/semantic-python-overview).
+
 ## Ruby tools
 Tools in this section are for those using Ruby to build RDF applications.
 

--- a/RDF-LAMP.md
+++ b/RDF-LAMP.md
@@ -3,7 +3,7 @@
 This page is for curating a list of free and open source tools --
 analogous to the [LAMP stack](https://en.wikipedia.org/wiki/LAMP_%28software_bundle%29) --
 that a new RDF user can easily download and use to build a "typical" RDF
-application.  The list is not intended to be exhaustive.  (See [Awesome Semantic Web]() for a broader list.)  Rather it is intended to be a starting point: to include only those tools that would be needed by _most_ RDF applications.
+application.  The list is not intended to be exhaustive.  (See [Awesome Semantic Web](https://github.com/semantalytics/awesome-semantic-web) for a broader list.)  Rather it is intended to be a starting point: to include only those tools that would be needed by _most_ RDF applications.
 The hope is to eventually bundle these tools into a single, common download, analogous to Red Hat or Ubuntu.
 
 ## Target applications


### PR DESCRIPTION
Even though most of the tools listed at semantic-python-overview probably do not qualify for being included here, the link might still be helpful for someone who wants to dive deeper.
Also, the link for Awesome Semantic Web was missing, so I added that too.
I hope this is okay.