### PR TITLE
Add Docker Compose template for SPARQL endpoint and RDF browser.

### DIFF
--- a/docker/.env.dist
+++ b/docker/.env.dist
@@ -1,0 +1,1 @@
+DBA_PASSWORD=changeme

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,4 +1,4 @@
-Simple template for a Docker Compose setup with a SPARQL Endpoint and RDF browser for a small knowledge base.
+Simple template for a Docker Compose setup based on [Virtuoso](https://github.com/openlink/virtuoso-opensource/), providing an RDF store, SPARQL Endpoint, and RDF browser (among other available features) for a quick knowledge base deployment.
 
 # Localize
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,13 +1,14 @@
 Simple template for a Docker Compose setup with a SPARQL Endpoint and RDF browser for a small knowledge base.
 
-# Run
+# Localize
 
-1. `docker compose up --build`
-2. test the SPARQL endpoint http://localhost:8890/sparql and the RDF browser at http://localhost:8080/
+1. Replace `rdf/example.ttl` with your knowledge base
+2. Add your namespaces to `initdb.d/setup.sql`
+3. Adapt `docker-compose.yml`
+4. Copy `.env.dist` to `.env` and change `DBA_PASSWORD`
 
-# Adapt
+# Start to use
 
-1. replace rdf/example.ttl with your knowledge base
-2. add your namespaces to initdb.d/setup.sql
-3. adapt docker-compose.yml
-4. copy .env.dist to .env and change DBA\_PASSWORD
+1. Run `docker compose up --build`
+2. Test the SPARQL endpoint at [`http://localhost:8890/sparql`](http://localhost:8890/sparql)
+2. Test the RDF browser at [`http://localhost:8080/`](http://localhost:8080/)

--- a/docker/README.md
+++ b/docker/README.md
@@ -11,4 +11,4 @@ Simple template for a Docker Compose setup based on [Virtuoso](https://github.co
 
 1. Run `docker compose up --build`
 2. Test the SPARQL endpoint at [`http://localhost:8890/sparql`](http://localhost:8890/sparql)
-2. Test the RDF browser at [`http://localhost:8080/`](http://localhost:8080/)
+2. Test the RDF browser at [`http://localhost:8080/ExInstance`](http://localhost:8080/ExInstance)

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,13 @@
+Simple template for a Docker Compose setup with a SPARQL Endpoint and RDF browser for a small knowledge base.
+
+# Run
+
+1. `docker compose up --build`
+2. test the SPARQL endpoint http://localhost:8890/sparql and the RDF browser at http://localhost:8080/
+
+# Adapt
+
+1. replace rdf/example.ttl with your knowledge base
+2. add your namespaces to initdb.d/setup.sql
+3. adapt docker-compose.yml
+4. copy .env.dist to .env and change DBA\_PASSWORD

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -16,20 +16,14 @@ services:
       - "127.0.0.1:8890:8890"
     restart: unless-stopped
 
-  rickview:
-    image: ghcr.io/konradhoeffner/rickview:master
+  lodview:
+    image: ghcr.io/konradhoeffner/lodview:22.05
     environment:
-      - RICKVIEW_KB_FILE=/rdf/example.ttl
-      - RICKVIEW_TITLE=Example Title
-      - RICKVIEW_SUBTITLE=Example Subtitle
-      - RICKVIEW_PREFIX=ex
-      - RICKVIEW_NAMESPACE=http://example.org/
-      - RICKVIEW_EXAMPLES=ExClass ExProperty ExInstance
-    volumes:
-      - ./rdf:/rdf:ro
+      - LodViewendpoint=http://virtuoso:8890/sparql
+      - LodViewIRInamespace=http://example.org/
+      - LodViewhomeUrl=/ExInstance
     ports:
       - "127.0.0.1:8080:8080"
+    depends_on:
+      - virtuoso
     restart: unless-stopped
-
-volumes:
-  rdf:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+
+  virtuoso:
+    image: openlink/virtuoso-opensource-7
+    environment:
+      - DBA_PASSWORD=${DBA_PASSWORD}
+      - VIRT_DATABASE_ERRORLOGLEVEL=3
+      - VIRT_SPARQL_DEFAULTGRAPH=http://example.org
+      - VIRT_SPARQL_DEFAULTQUERY=select distinct * {?s ?p ?o.} LIMIT 100
+      - VIRT_PARAMETERS_DIRSALLOWED=., /usr/local/virtuoso-opensource/share/virtuoso/vad, /rdf
+      - VIRT_PLUGINS_-=-
+    volumes:
+      - ./rdf:/rdf:ro
+      - ./initdb.d:/opt/virtuoso-opensource/initdb.d:ro
+    ports:
+      - "127.0.0.1:8890:8890"
+    restart: unless-stopped
+
+  rickview:
+    image: ghcr.io/konradhoeffner/rickview:master
+    environment:
+      - RICKVIEW_KB_FILE=/rdf/example.ttl
+      - RICKVIEW_TITLE=Example Title
+      - RICKVIEW_SUBTITLE=Example Subtitle
+      - RICKVIEW_PREFIX=ex
+      - RICKVIEW_NAMESPACE=http://example.org/
+      - RICKVIEW_EXAMPLES=ExClass ExProperty ExInstance
+    volumes:
+      - ./rdf:/rdf:ro
+    ports:
+      - "127.0.0.1:8080:8080"
+    restart: unless-stopped
+
+volumes:
+  rdf:

--- a/docker/initdb.d/setup.sql
+++ b/docker/initdb.d/setup.sql
@@ -1,0 +1,9 @@
+log_message('Setup: Activate CORS');
+update DB.DBA.HTTP_PATH set HP_OPTIONS = serialize(vector('browse_sheet', '', 'noinherit', 'yes', 'cors', '*', 'cors_restricted', 0))  where HP_LPATH = '/sparql';
+log_message('Setup: Declare namespaces');
+DB.DBA.XML_SET_NS_DECL ('ex', 'http://example.org/', 2);
+log_message('Setup: Load data');
+ld_dir_all ('/rdf/', '*.ttl', 'http://example.org');
+rdf_loader_run();
+log_message('Setup: Finished');
+

--- a/docker/rdf/example.ttl
+++ b/docker/rdf/example.ttl
@@ -1,19 +1,20 @@
-@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
-@prefix owl: <http://www.w3.org/2002/07/owl#>.
-@prefix ex: <http://example.org/>.
+PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
+PREFIX  owl: <http://www.w3.org/2002/07/owl#>
+PREFIX   ex: <http://example.org/>
 
 ex:ExClass
-  a owl:Class;
-  rdfs:comment "an example class"@en;
-  rdfs:label "example class"@en.
+  a             owl:Class ;
+  rdfs:comment  "an example class"@en ;
+  rdfs:label    "example class"@en .
 
 ex:ExInstance
-  ex:exProperty 5;
-  a ex:ExClass;
-  rdfs:comment "an example instance."@en;
-  rdfs:label "example instance"@en.
+  a             ex:ExClass ;
+  ex:exProperty 5 ;
+  rdfs:comment  "an example instance."@en ;
+  rdfs:label    "example instance"@en .
 
 ex:exProperty
-  a owl:DatatypeProperty;
-  rdfs:domain ex:ExClass;
-  rdfs:label "Beispielproperty"@de, "example property"@en.
+  a             owl:DatatypeProperty ;
+  rdfs:domain   ex:ExClass ;
+  rdfs:label    "Beispielproperty"@de ,
+                "example property"@en .

--- a/docker/rdf/example.ttl
+++ b/docker/rdf/example.ttl
@@ -1,0 +1,19 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#>.
+@prefix owl: <http://www.w3.org/2002/07/owl#>.
+@prefix ex: <http://example.org/>.
+
+ex:ExClass
+  a owl:Class;
+  rdfs:comment "an example class"@en;
+  rdfs:label "example class"@en.
+
+ex:ExInstance
+  ex:exProperty 5;
+  a ex:ExClass;
+  rdfs:comment "an example instance."@en;
+  rdfs:label "example instance"@en.
+
+ex:exProperty
+  a owl:DatatypeProperty;
+  rdfs:domain ex:ExClass;
+  rdfs:label "Beispielproperty"@de, "example property"@en.


### PR DESCRIPTION
Simple template for a Docker Compose setup with a SPARQL Endpoint and RDF browser for a small knowledge base.
Resolves #96.